### PR TITLE
Fix issue 9: configurable test JWTs from environment

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,45 @@
+# Server
+PORT=22024
+NODE_ENV=development
+
+# JWT
+JWT_SECRET=your-jwt-secret-here
+JWT_EXPIRES_IN=24h
+
+# Optional test JWTs. Leave empty or unset to disable test JWT support.
+# Expected format: JSON array of JWT strings.
+# TEST_JWTS=["eyJhbGciOi...test-token-1","eyJhbGciOi...test-token-2"]
+TEST_JWTS=
+
+# Google Auth
+GOOGLE_CLIENT_ID=your-google-client-id
+GOOGLE_CLIENT_SECRET=your-google-client-secret
+GOOGLE_PACKAGE_NAME=com.animatedsticker.aistickers
+
+# Apple Auth
+APPLE_CLIENT_ID=your-apple-client-id
+
+# HMAC (App Authentication)
+CLIENT_ID=ai-stickers
+CLIENT_SECRET=your-client-secret-here
+
+# Data
+DATA_DIR=/var/www/aiStickers_Backend/data
+
+# Google Play
+GOOGLE_PLAY_SERVICE_ACCOUNT={"type":"service_account",...}
+
+# i18n / POEditor
+POEDITOR_API_TOKEN=your-poeditor-api-token
+POEDITOR_PROJECT_ID=your-poeditor-project-id
+
+# Replicate AI
+REPLICATE_API_TOKEN=your-replicate-api-token
+REPLICATE_MODEL=google/nano-banana
+REPLICATE_IMG2VID_MODEL=bytedance/seedance-1-pro
+
+# HMAC window
+SIG_WINDOW_SEC=300
+
+# Telegram Bot
+TELEGRAM_BOT_TOKEN=your-telegram-bot-token

--- a/scripts/verify-test-jwts.js
+++ b/scripts/verify-test-jwts.js
@@ -1,0 +1,35 @@
+/**
+ * Minimal verification for TEST_JWTS parsing.
+ * Covers the cases requested in issue #9:
+ *   - absent variable
+ *   - empty variable
+ *   - invalid JSON
+ *   - non-array JSON
+ *   - valid array with tokens
+ *
+ * Run with: node scripts/verify-test-jwts.js
+ */
+
+import { parseTestJwts, env } from '../src/config/env.js';
+
+function assert(condition, message) {
+  if (!condition) {
+    console.error(`❌ FAIL: ${message}`);
+    process.exit(1);
+  }
+  console.log(`✅ PASS: ${message}`);
+}
+
+assert(Array.isArray(env.TEST_JWTS), 'env.TEST_JWTS is always an array');
+assert(env.TEST_JWTS.length === 0, 'env.TEST_JWTS is empty when variable is absent');
+
+assert(parseTestJwts(undefined).length === 0, 'undefined returns empty array');
+assert(parseTestJwts('').length === 0, 'empty string returns empty array');
+assert(parseTestJwts('   ').length === 0, 'whitespace-only string returns empty array');
+assert(parseTestJwts('not-json').length === 0, 'invalid JSON returns empty array');
+assert(parseTestJwts('{}').length === 0, 'non-array JSON returns empty array');
+assert(parseTestJwts('["token-1"]').length === 1, 'valid array with one token returns one token');
+assert(parseTestJwts('["token-1", "token-2"]').length === 2, 'valid array with two tokens returns two tokens');
+assert(parseTestJwts('["token-1", "", 123, "token-2"]').length === 2, 'filters out empty strings and non-strings');
+
+console.log('All TEST_JWTS parsing checks passed.');

--- a/src/config/env.js
+++ b/src/config/env.js
@@ -9,6 +9,26 @@ const __dirname = path.dirname(__filename);
 dotenv.config({ path: path.join(__dirname, '../../.env') });
 
 /**
+ * Parse TEST_JWTS environment variable into an array of test JWT strings.
+ * Accepts a JSON array string. Returns an empty array if the variable is
+ * unset, empty, invalid JSON, or not an array of strings.
+ */
+export function parseTestJwts(value) {
+  if (!value || value.trim() === '') {
+    return [];
+  }
+  try {
+    const parsed = JSON.parse(value);
+    if (!Array.isArray(parsed)) {
+      return [];
+    }
+    return parsed.filter(item => typeof item === 'string' && item.trim() !== '');
+  } catch {
+    return [];
+  }
+}
+
+/**
  * Environment Configuration
  * Centralizes all environment variables
  */
@@ -20,6 +40,7 @@ export const env = {
   // JWT
   JWT_SECRET: process.env.JWT_SECRET,
   JWT_EXPIRES_IN: process.env.JWT_EXPIRES_IN || '24h',
+  TEST_JWTS: parseTestJwts(process.env.TEST_JWTS),
   
   // Google Auth
   GOOGLE_CLIENT_ID: process.env.GOOGLE_CLIENT_ID,

--- a/src/infrastructure/auth/jwt.service.js
+++ b/src/infrastructure/auth/jwt.service.js
@@ -9,6 +9,25 @@ export class JwtService {
   constructor() {
     this.secret = env.JWT_SECRET;
     this.expiresIn = env.JWT_EXPIRES_IN || '24h';
+    this.testJwts = env.TEST_JWTS || [];
+  }
+
+  /**
+   * Check if the provided token is a configured test JWT.
+   * @param {string} token - JWT token
+   * @returns {boolean}
+   */
+  isTestJwt(token) {
+    return this.testJwts.includes(token);
+  }
+
+  /**
+   * Decode a test JWT without signature verification.
+   * @param {string} token - JWT token
+   * @returns {Object|null} Decoded payload
+   */
+  decodeTestJwt(token) {
+    return jwt.decode(token);
   }
   
   /**

--- a/src/infrastructure/web/middleware/auth.middleware.js
+++ b/src/infrastructure/web/middleware/auth.middleware.js
@@ -24,7 +24,21 @@ export class AuthMiddleware {
       }
       
       const token = authHeader.substring(7);
-      const decoded = this.jwtService.verify(token);
+      let decoded;
+
+      try {
+        decoded = this.jwtService.verify(token);
+      } catch (error) {
+        // If real verification fails, allow configured test JWTs
+        if (this.jwtService.isTestJwt(token)) {
+          decoded = this.jwtService.decodeTestJwt(token);
+          if (!decoded) {
+            throw new Error('Invalid test token');
+          }
+        } else {
+          throw error;
+        }
+      }
       
       // Attach user info to request
       req.user = decoded;
@@ -63,17 +77,29 @@ export class AuthMiddleware {
       try {
         decoded = this.jwtService.verify(token);
       } catch (expError) {
-        // If expired, try again ignoring expiration
-        decoded = this.jwtService.verifyWithoutExpiration(token);
-        
-        // Check if it's too old (more than 7 days)
-        const now = Math.floor(Date.now() / 1000);
-        if (decoded.exp && (now - decoded.exp) > 604800) {
-          console.log('❌ Token too old (>7d)');
-          return res.status(401).json({ 
-            error: 'Token expired',
-            message: 'Please login again' 
-          });
+        try {
+          // If expired, try again ignoring expiration
+          decoded = this.jwtService.verifyWithoutExpiration(token);
+          
+          // Check if it's too old (more than 7 days)
+          const now = Math.floor(Date.now() / 1000);
+          if (decoded.exp && (now - decoded.exp) > 604800) {
+            console.log('❌ Token too old (>7d)');
+            return res.status(401).json({ 
+              error: 'Token expired',
+              message: 'Please login again' 
+            });
+          }
+        } catch (verifyError) {
+          // Allow configured test JWTs without signature verification
+          if (this.jwtService.isTestJwt(token)) {
+            decoded = this.jwtService.decodeTestJwt(token);
+            if (!decoded) {
+              throw new Error('Invalid test token');
+            }
+          } else {
+            throw verifyError;
+          }
         }
       }
       


### PR DESCRIPTION
## Summary\n- Fixes #9.\n- Adds TEST_JWTS env parsing as a JSON array of JWT strings.\n- Test JWTs are accepted only when explicitly configured; absent/empty/invalid values result in no test JWTs enabled.\n- Real JWT verification flow remains unchanged.\n- Adds .env.example with the TEST_JWTS example and instructions.\n\n## Tests\n- Ran node --check on modified files and index.js.\n- Ran node scripts/verify-test-jwts.js, covering absent, empty, invalid, and valid TEST_JWTS values.\n- No test runner configured in the project.